### PR TITLE
Add standalone letter test page

### DIFF
--- a/jua-app/app/letter-test/page.tsx
+++ b/jua-app/app/letter-test/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useMemo, useState } from "react";
+import CloseCurtain from "@/components/CloseCurtain";
+import KnotGate from "@/components/KnotGate";
+import LetterScroll from "@/components/LetterScroll";
+import PetalsCanvas from "@/components/PetalsCanvas";
+
+type Stage = "closed" | "opened" | "closing" | "closed-final";
+
+export default function LetterTestPage() {
+  const [stage, setStage] = useState<Stage>("closed");
+  const [burstKey, setBurstKey] = useState(0);
+
+  const mainStyle = useMemo(() => {
+    return {
+      minHeight: "100vh",
+      overflow: "hidden",
+      position: "relative",
+      background: "#e9e3d7",
+      color: "var(--ink)",
+      "--paper": "#faf6ef",
+      "--ink": "#2a2826",
+      "--red": "#bb2b3b",
+      fontFamily: 'ui-serif, "Iowan Old Style", "Nanum Myeongjo", serif',
+    } as CSSProperties;
+  }, []);
+
+  return (
+    <main style={mainStyle}>
+      {stage === "closed" && (
+        <KnotGate
+          onUntie={() => {
+            setStage("opened");
+            setBurstKey((value) => value + 1);
+          }}
+        />
+      )}
+
+      {stage === "opened" && (
+        <>
+          <PetalsCanvas burstKey={burstKey} />
+          <LetterScroll
+            onEndReach={() => {
+              setStage("closing");
+            }}
+          />
+        </>
+      )}
+
+      {stage === "closing" && (
+        <CloseCurtain
+          onClosed={() => {
+            setStage("closed-final");
+          }}
+        />
+      )}
+
+      {stage === "closed-final" && (
+        <div
+          style={{
+            height: "100vh",
+            display: "grid",
+            placeItems: "center",
+            background: "#e9e3d7",
+          }}
+        >
+          <button
+            onClick={() => {
+              setStage("closed");
+              setBurstKey((value) => value + 1);
+            }}
+            style={{
+              padding: "12px 18px",
+              border: "1px solid #000",
+              background: "#fff",
+            }}
+          >
+            다시 열기
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/jua-app/components/CloseCurtain.tsx
+++ b/jua-app/components/CloseCurtain.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function CloseCurtain({ onClosed }: { onClosed: () => void }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => setVisible(true));
+    const timeout = window.setTimeout(() => {
+      onClosed();
+    }, 900);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
+  }, [onClosed]);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        display: "grid",
+        placeItems: "center",
+        background: "rgba(0,0,0,0.05)",
+      }}
+    >
+      <div
+        style={{
+          width: "min(820px, 86vw)",
+          height: "70vh",
+          background: "var(--paper)",
+          border: "1px solid #d8cdbb",
+          boxShadow: "0 30px 80px rgba(0,0,0,0.18)",
+          transform: `scaleY(${visible ? 1 : 0.1})`,
+          opacity: visible ? 1 : 0,
+          borderRadius: 18,
+          transition: "transform 0.6s cubic-bezier(0.2,0.8,0.2,1), opacity 0.6s cubic-bezier(0.2,0.8,0.2,1)",
+          transformOrigin: "center",
+        }}
+      />
+    </div>
+  );
+}

--- a/jua-app/components/KnotGate.tsx
+++ b/jua-app/components/KnotGate.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "@/styles/knot.module.css";
+
+type Point = { x: number; y: number };
+
+export default function KnotGate({ onUntie }: { onUntie: () => void }) {
+  const radius = 120;
+  const sealRef = useRef<HTMLDivElement>(null);
+  const startPointer = useRef<Point | null>(null);
+  const startOffset = useRef<Point>({ x: 0, y: 0 });
+  const [position, setPosition] = useState<Point>({ x: 0, y: 0 });
+  const [transitioning, setTransitioning] = useState(false);
+  const [released, setReleased] = useState(false);
+  const [triggered, setTriggered] = useState(false);
+
+  const dist = useMemo(() => Math.hypot(position.x, position.y), [position]);
+
+  const resetTransition = useCallback(() => {
+    if (!transitioning) return;
+    const id = window.setTimeout(() => setTransitioning(false), 260);
+    return () => window.clearTimeout(id);
+  }, [transitioning]);
+
+  useEffect(() => resetTransition(), [transitioning, resetTransition]);
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!startPointer.current || released) return;
+      const current: Point = { x: event.clientX, y: event.clientY };
+      const nextX = current.x - startPointer.current.x + startOffset.current.x;
+      const nextY = current.y - startPointer.current.y + startOffset.current.y;
+      setTransitioning(false);
+      setPosition({ x: nextX, y: nextY });
+    },
+    [released]
+  );
+
+  const endDrag = useCallback(
+    (event?: PointerEvent) => {
+      if (!startPointer.current) return;
+      if (event?.pointerId !== undefined) {
+        sealRef.current?.releasePointerCapture(event.pointerId);
+      }
+      startPointer.current = null;
+
+      if (released) return;
+
+      const distance = Math.hypot(position.x, position.y);
+      if (distance > radius + 40) {
+        setReleased(true);
+        setTransitioning(true);
+        setPosition(({ x, y }) => ({ x: x + 200, y: y - 200 }));
+        window.setTimeout(() => {
+          if (!triggered) {
+            setTriggered(true);
+            onUntie();
+          }
+        }, 320);
+        return;
+      }
+
+      setTransitioning(true);
+      setPosition({ x: 0, y: 0 });
+    },
+    [onUntie, position.x, position.y, radius, released, triggered]
+  );
+
+  const handlePointerUp = useCallback(
+    (event: PointerEvent) => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      endDrag(event);
+    },
+    [endDrag, handlePointerMove]
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (released) return;
+      event.preventDefault();
+      startPointer.current = { x: event.clientX, y: event.clientY };
+      startOffset.current = position;
+      setTransitioning(false);
+      sealRef.current?.setPointerCapture(event.pointerId);
+      window.addEventListener("pointermove", handlePointerMove, { passive: true });
+      window.addEventListener("pointerup", handlePointerUp, { passive: true });
+      window.addEventListener("pointercancel", handlePointerUp, { passive: true });
+    },
+    [handlePointerMove, handlePointerUp, position, released]
+  );
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+  }, [handlePointerMove, handlePointerUp]);
+
+  const ringScale = 1 + Math.min(dist / radius, 1) * 0.06;
+  const hintOpacity = dist >= radius ? 0 : dist >= radius * 0.6 ? 0.2 : 0.6;
+
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.paper} />
+      <div
+        className={styles.ring}
+        style={{ transform: `scale(${ringScale.toFixed(3)})` }}
+      />
+      <div
+        ref={sealRef}
+        className={styles.seal}
+        onPointerDown={handlePointerDown}
+        style={{
+          transform: `translate3d(${position.x}px, ${position.y}px, 0)`,
+          transition: transitioning ? "transform 0.25s ease" : "none",
+        }}
+      >
+        <span>결</span>
+      </div>
+      <div className={styles.hint} style={{ opacity: hintOpacity }}>
+        클릭 & 드래그로 매듭을 풀어주세요
+      </div>
+    </div>
+  );
+}

--- a/jua-app/components/LetterScroll.tsx
+++ b/jua-app/components/LetterScroll.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "@/styles/letter.module.css";
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export default function LetterScroll({ onEndReach }: { onEndReach: () => void }) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [progress, setProgress] = useState(0);
+  const [locked, setLocked] = useState(false);
+
+  const updateProgress = useCallback(() => {
+    const stage = stageRef.current;
+    if (!stage) return;
+    const scrollY = window.scrollY;
+    const stageTop = stage.offsetTop;
+    const stageHeight = stage.offsetHeight;
+    const viewport = window.innerHeight;
+    const scrollRange = Math.max(stageHeight - viewport, 1);
+    const scrolled = clamp(scrollY - stageTop, 0, scrollRange);
+    const value = clamp(scrolled / scrollRange, 0, 1);
+    setProgress(value);
+    return value;
+  }, []);
+
+  useEffect(() => {
+    let ticking = false;
+    const handleScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        updateProgress();
+        ticking = false;
+      });
+    };
+
+    const handleResize = () => {
+      updateProgress();
+    };
+
+    updateProgress();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [updateProgress]);
+
+  useEffect(() => {
+    if (locked || progress < 0.985) return;
+    setLocked(true);
+    const stage = stageRef.current;
+    const targetTop = stage ? stage.offsetTop + stage.offsetHeight : window.scrollY;
+    window.scrollTo({ top: targetTop, behavior: "smooth" });
+    const timeout = window.setTimeout(() => {
+      onEndReach();
+    }, 220);
+    return () => window.clearTimeout(timeout);
+  }, [locked, onEndReach, progress]);
+
+  const leftRotation = useMemo(() => -8 + progress * 20, [progress]);
+  const rightRotation = useMemo(() => 8 - progress * 20, [progress]);
+
+  return (
+    <div className={styles.stage} ref={stageRef}>
+      <aside
+        className={`${styles.side} ${styles.left}`}
+        style={{ transform: `rotate(${leftRotation}deg)` }}
+      />
+      <aside
+        className={`${styles.side} ${styles.right}`}
+        style={{ transform: `rotate(${rightRotation}deg)` }}
+      />
+
+      <section className={styles.letter}>
+        <header className={styles.header}>
+          <div className={styles.ribbon} />
+          <h1>서신(書信)</h1>
+          <p className={styles.sub}>달빛 아래 붓을 적시어…</p>
+        </header>
+
+        <article className={styles.body}>
+          <p>
+            바람이 잔잔한 밤, 당신께 전해지는 글월 하나. 마음의 결을 따라 종이가 한 장씩
+            넘겨지듯, 이 편지도 천천히, 그러나 분명하게 닿기를 바랍니다.
+          </p>
+          <p>
+            … 여기에 실제 편지 내용을 길게 넣어도 좋고, 여러 문단과 삽화를 섞으며 스크롤
+            흐름에 맞춰 연출할 수 있어요.
+          </p>
+          <p>
+            스크롤을 내릴수록 양옆의 서신 장식이 방향에 맞춰 회전하며 화면의 몰입감을
+            높입니다.
+          </p>
+          <p>끝까지 내리면 편지가 조용히 닫혀요.</p>
+          <div style={{ height: "40vh" }} />
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/jua-app/components/PetalsCanvas.tsx
+++ b/jua-app/components/PetalsCanvas.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type Petal = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  rot: number;
+  vr: number;
+  life: number;
+};
+
+export default function PetalsCanvas({ burstKey }: { burstKey: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const petalsRef = useRef<Petal[]>([]);
+  const rafRef = useRef<number>();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const petals = petalsRef;
+    const raf = rafRef;
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+
+    const resize = () => {
+      canvas.width = Math.floor(canvas.clientWidth * dpr);
+      canvas.height = Math.floor(canvas.clientHeight * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(canvas);
+    resize();
+
+    const width = () => canvas.clientWidth;
+    const height = () => canvas.clientHeight;
+
+    const spawnBurst = (count = 90) => {
+      for (let i = 0; i < count; i += 1) {
+        petals.current.push({
+          x: width() / 2,
+          y: height() / 2,
+          vx: (Math.random() * 2 - 1) * 2.5,
+          vy: -(Math.random() * 2 + 1) * 2.2,
+          r: 6 + Math.random() * 8,
+          rot: Math.random() * Math.PI * 2,
+          vr: (Math.random() * 2 - 1) * 0.02,
+          life: 1,
+        });
+      }
+    };
+
+    let previous = performance.now();
+    const tick = (time: number) => {
+      const dt = Math.min(33, time - previous);
+      previous = time;
+      ctx.clearRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+
+      for (const petal of petals.current) {
+        petal.vy += 0.002 * dt;
+        petal.vx += Math.sin(time * 0.001 + petal.rot) * 0.001 * dt;
+        petal.x += petal.vx * (dt / 16);
+        petal.y += petal.vy * (dt / 16);
+        petal.rot += petal.vr * dt;
+        petal.life -= petal.y > height() + 50 ? 0.02 : 0.004;
+      }
+
+      petals.current = petals.current.filter((petal) => petal.life > 0);
+
+      for (const petal of petals.current) {
+        ctx.save();
+        ctx.globalAlpha = Math.max(0, Math.min(1, petal.life));
+        ctx.translate(petal.x, petal.y);
+        ctx.rotate(petal.rot);
+        ctx.fillStyle = "rgba(219,95,122,0.9)";
+        ctx.beginPath();
+        ctx.ellipse(0, 0, petal.r, petal.r * 0.6, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+      }
+
+      raf.current = window.requestAnimationFrame(tick);
+    };
+
+    raf.current = window.requestAnimationFrame(tick);
+    spawnBurst(90);
+
+    return () => {
+      if (raf.current) {
+        window.cancelAnimationFrame(raf.current);
+      }
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const petals = petalsRef.current;
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+
+    for (let i = 0; i < 120; i += 1) {
+      petals.push({
+        x: width / 2,
+        y: height / 2,
+        vx: (Math.random() * 2 - 1) * 3.2,
+        vy: -(Math.random() * 2 + 1) * 2.8,
+        r: 6 + Math.random() * 10,
+        rot: Math.random() * Math.PI * 2,
+        vr: (Math.random() * 2 - 1) * 0.03,
+        life: 1,
+      });
+    }
+  }, [burstKey]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ position: "fixed", inset: 0, pointerEvents: "none" }}
+    />
+  );
+}

--- a/jua-app/styles/knot.module.css
+++ b/jua-app/styles/knot.module.css
@@ -1,0 +1,50 @@
+.wrap {
+  position: relative;
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: radial-gradient(1200px 800px at 50% 40%, #faf6ef 0%, #efe8db 65%, #e4dccd 100%);
+}
+.paper {
+  position: absolute;
+  inset: 10% 8%;
+  background: var(--paper);
+  border: 1px solid #d8cdbb;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.18);
+}
+.ring {
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  border: 6px solid var(--red);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.1);
+  background: radial-gradient(circle at 30% 30%, #fff0 0 80px, rgba(187, 43, 59, 0.06) 120px);
+  transition: transform 0.2s ease;
+}
+.seal {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: var(--red);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  cursor: grab;
+  user-select: none;
+  box-shadow: 0 10px 25px rgba(187, 43, 59, 0.35);
+  touch-action: none;
+  transition: transform 0.25s ease;
+}
+.seal:active {
+  cursor: grabbing;
+}
+.hint {
+  position: absolute;
+  bottom: 8vh;
+  font-size: 14px;
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}

--- a/jua-app/styles/letter.module.css
+++ b/jua-app/styles/letter.module.css
@@ -1,0 +1,63 @@
+.stage {
+  position: relative;
+  height: 240vh;
+  background: radial-gradient(1200px 800px at 50% 10%, #f9f4ea 0%, #efe7d9 70%, #e5dccd);
+}
+.side {
+  position: sticky;
+  top: 10vh;
+  width: 180px;
+  height: 420px;
+  background: linear-gradient(#d9c9b5, #bfae97);
+  border: 1px solid #a28f76;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease;
+}
+.left {
+  left: 4vw;
+  border-top-left-radius: 12px;
+  border-bottom-left-radius: 12px;
+}
+.right {
+  right: 4vw;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
+  float: right;
+}
+.letter {
+  position: relative;
+  width: min(820px, 86vw);
+  margin: 0 auto;
+  padding-top: 16vh;
+}
+.header {
+  position: sticky;
+  top: 0;
+  padding-top: 4vh;
+  padding-bottom: 2vh;
+  text-align: center;
+  background: linear-gradient(180deg, rgba(249, 244, 234, 0.95) 0%, rgba(249, 244, 234, 0.65) 100%);
+  z-index: 2;
+}
+.ribbon {
+  width: 90px;
+  height: 8px;
+  margin: 0 auto 10px;
+  background: var(--red);
+}
+.sub {
+  margin: 4px 0 0;
+  opacity: 0.7;
+  font-size: 14px;
+}
+.body {
+  margin-top: 6vh;
+  background: var(--paper);
+  border: 1px solid #d8cdbb;
+  padding: 8vh 8vw;
+  line-height: 1.9;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.16);
+}
+.body p {
+  margin: 0 0 2.2em;
+}


### PR DESCRIPTION
## Summary
- add a `/letter-test` route that reproduces the interactive letter flow with drag-to-open, scrolling letter, and closing curtain
- implement gate, letter scroll, petals canvas, and curtain components without external animation libraries
- add scoped CSS modules to style the knot gate and letter presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf69680bb8832683a13b023f15142d